### PR TITLE
Add the ability to generate and restore CSV for translations that are missing only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 Export your ember-i18n localization files to a CSV file for translators:
 
 ```
-node to-csv path_to_locales_folder i18n.csv
+node to-csv path_to_locales_folder i18n.csv [--missing-only]
 ```
+
+`--missing-only` means the generated CSV will only contain keys where there is a missing translation in one of the locales
 
 and import back in when you get them back:
 
 ```
-node to-js i18n.csv path_to_locales_folder [--jshint-ignore]
+node to-js i18n.csv path_to_locales_folder [--jshint-ignore] [--merge]
 ```
+
+`--merge` means that any keys present in the CSV will overwrite the ones present in the destination locale files but if the key is not present then the existing key will be kept in place.

--- a/to-csv.js
+++ b/to-csv.js
@@ -6,6 +6,7 @@ require('6to5/register');
 
 var localesPath = argv._[0];
 var csvPath = argv._[1];
+var onlyMissing = argv['only-missing'];
 
 var locales = fs.readdirSync(localesPath);
 
@@ -58,7 +59,9 @@ for (var columnIndex in locales) {
 var lines = [];
 lines.push(['key'].concat(locales.map(function(locale) { return locale.replace('.js', ''); })));
 for (var i in keys) {
-  lines.push([keys[i]].concat(rows[i]));
+  if(!onlyMissing || rows[i].indexOf('') > -1) {
+	lines.push([keys[i]].concat(rows[i]));
+  }
 }
 
 stringify(lines, function(err, csv) {

--- a/to-csv.js
+++ b/to-csv.js
@@ -60,7 +60,7 @@ var lines = [];
 lines.push(['key'].concat(locales.map(function(locale) { return locale.replace('.js', ''); })));
 for (var i in keys) {
   if(!onlyMissing || rows[i].indexOf('') > -1) {
-	lines.push([keys[i]].concat(rows[i]));
+    lines.push([keys[i]].concat(rows[i]));
   }
 }
 

--- a/to-js.js
+++ b/to-js.js
@@ -3,10 +3,12 @@ var path = require('path');
 var parse = require('csv-parse');
 var EOL = require('os').EOL;
 var argv = require('yargs').argv;
+require('6to5/register');
 
 var csvPath = argv._[0];
 var localesPath = argv._[1];
 var ignoreJshint = argv['jshint-ignore'];
+var merge = argv['merge'];
 
 var csv = fs.readFileSync(csvPath, 'utf8');
 
@@ -15,7 +17,12 @@ parse(csv, function(err, lines) {
 
   var objs = [];
   for (var i in locales) {
-    objs.push({});
+	var obj = {};
+	if(merge){
+		var filePath = path.join(localesPath, locales[i], 'translations.js');
+		obj = require(filePath);
+	}
+    objs.push(obj);
   }
 
   function recurse(keySections, obj, value) {

--- a/to-js.js
+++ b/to-js.js
@@ -17,11 +17,11 @@ parse(csv, function(err, lines) {
 
   var objs = [];
   for (var i in locales) {
-	var obj = {};
-	if(merge){
-		var filePath = path.join(localesPath, locales[i], 'translations.js');
-		obj = require(filePath);
-	}
+    var obj = {};
+    if(merge){
+      var filePath = path.join(localesPath, locales[i], 'translations.js');
+      obj = require(filePath);
+    }
     objs.push(obj);
   }
 


### PR DESCRIPTION
Add command line switch that hides completed translations from the output csv and also allows for merging only changed keys back into the js files.  

This allows for incremental localization by generating a CSV with only the keys the translator needs to work on. 