### PR TITLE
added dotted key export notation to to-js.

### DIFF
--- a/bin/ember-i18n-csv.js
+++ b/bin/ember-i18n-csv.js
@@ -14,6 +14,9 @@ var argv = require('yargs')
     },
     'merge': {
       type: 'boolean'
+    },
+    'dotted':{
+      type: 'boolean'
     }
   })
   .argv;
@@ -24,11 +27,13 @@ var csvPath = argv['csv-path'];
 var ignoreJshint = argv['jshint-ignore'];
 var onlyMissing = argv['only-missing'];
 var merge = argv['merge'];
+var dotted = argv['dotted'];
 
 var options = {
   ignoreJshint: ignoreJshint,
   onlyMissing: onlyMissing,
-  merge: merge
+  merge: merge,
+  dotted:dotted
 };
 
 emberI18nCsv(direction, localesPath, csvPath, options);

--- a/lib/to-js.js
+++ b/lib/to-js.js
@@ -10,7 +10,7 @@ const readFile = denodeify(fs.readFile);
 const writeFile = denodeify(fs.writeFile);
 const parse = denodeify(csvParse);
 
-export default function(csvPath, localesPath, { ignoreJshint, merge } = {}) {
+export default function(csvPath, localesPath, { ignoreJshint, merge, dotted } = {}) {
   return readFile(csvPath, 'utf8').then(csv => {
     return parse(csv);
   }).then(lines => {
@@ -30,14 +30,18 @@ export default function(csvPath, localesPath, { ignoreJshint, merge } = {}) {
     }
 
     function recurse(keySections, obj, value) {
-      let key = keySections[0];
-      if (keySections.length > 1) {
-        if (!obj[key]) {
-          obj[key] = {};
+      if(dotted){
+        obj[keySections.join('.')] = value;
+      }else{
+        let key = keySections[0];
+        if (keySections.length > 1) {
+          if (!obj[key]) {
+            obj[key] = {};
+          }
+          recurse(keySections.slice(1), obj[key], value);
+        } else {
+          obj[key] = value;
         }
-        recurse(keySections.slice(1), obj[key], value);
-      } else {
-        obj[key] = value;
       }
     }
 

--- a/test/acceptance/to-js-test.js
+++ b/test/acceptance/to-js-test.js
@@ -81,4 +81,28 @@ describe('acceptance - to-js', function() {
       }).catch(done);
     });
   });
+
+  it('handles option --dotted', function(done) {
+    let ps = spawn(process.execPath, [
+      'bin/ember-i18n-csv.js',
+      'to-js',
+      '--csv-path=test/fixtures/i18n-dotted.csv',
+      '--locales-path=tmp/locales',
+      '--dotted'
+    ]);
+
+    let out = '';
+    let err = '';
+    ps.stdout.on('data', buffer => out += buffer);
+    ps.stderr.on('data', buffer => err += buffer);
+
+    ps.on('exit', () => {
+      expect(out).to.equal('');
+      expect(err).to.equal('');
+      areDirsEqual('tmp/locales', 'test/fixtures/locales-dotted').then(areSame => {
+        expect(areSame).to.be.true;
+        done();
+      }).catch(done);
+    });
+  });
 });

--- a/test/fixtures/i18n-dotted.csv
+++ b/test/fixtures/i18n-dotted.csv
@@ -1,0 +1,5 @@
+key,en-us,nl-nl,pt-br
+node1.node1-1,Industries,Industrieën,Indústrias
+node1.node1-2.node1-2-1,test,test,test
+
+

--- a/test/fixtures/locales-dotted/en-us/translations.js
+++ b/test/fixtures/locales-dotted/en-us/translations.js
@@ -1,0 +1,4 @@
+export default {
+    "node1.node1-1":"Industries",
+    "node1.node1-2.node1-2-1":"test"
+};

--- a/test/fixtures/locales-dotted/nl-nl/translations.js
+++ b/test/fixtures/locales-dotted/nl-nl/translations.js
@@ -1,0 +1,4 @@
+export default {
+    "node1.node1-1":"Industrieën",
+    "node1.node1-2.node1-2-1":"test"
+};

--- a/test/fixtures/locales-dotted/pt-br/translations.js
+++ b/test/fixtures/locales-dotted/pt-br/translations.js
@@ -1,0 +1,5 @@
+export default {
+    "node1.node1-1":"Indústrias",
+    "node1.node1-2.node1-2-1":"test"
+};
+

--- a/test/integration/ember-i18n-csv-test.js
+++ b/test/integration/ember-i18n-csv-test.js
@@ -64,6 +64,7 @@ describe('integration - ember-i18n-csv', function() {
         });
       });
     });
+
     describe('merge', function() {
       beforeEach(function() {
         fs.copySync('test/fixtures/locales-with-missing-keys', 'tmp/locales', { clobber: true });
@@ -80,6 +81,14 @@ describe('integration - ember-i18n-csv', function() {
           });
         });
       });
+
+      it('handles option --dotted', function() {
+      return emberI18nCsv('to-js', 'tmp/locales', 'test/fixtures/i18n-dotted.csv', { dotted: true }).then(() => {
+        return areDirsEqual('tmp/locales', 'test/fixtures/locales-dotted').then(areSame => {
+          expect(areSame).to.be.true;
+        });
+      });
+    });
     });
   });
 


### PR DESCRIPTION
ember-i18n has dotted key definition along with nested object definition. https://github.com/jamesarosen/ember-i18n/wiki/Doc:-Defining-Translations

This request adds an option(--dotted) which allows dotted key export.