### PR TITLE
Wrap JSON.parse to trap an print exception details upon parse failure.

### DIFF
--- a/lib/to-csv.js
+++ b/lib/to-csv.js
@@ -70,9 +70,13 @@ export default function(localesPath, csvPath, { onlyMissing } = {}) {
     for (let columnIndex in filePaths) {
       let filePath = filePaths[columnIndex];
 
-      let json = parseJsonFromJsFile(filePath);
-
-      recurse(json, columnIndex, 0, '');
+      try {
+        var json = (0, _parseJsonFromJsFile2.default)(filePath);
+        recurse(json, columnIndex, 0, '');
+      } catch (e) {
+        console.log("Failed parsing", filePath, "\nError:", e.name, "\nDescription:", e.message);
+        throw new Error();
+      }
     }
 
     let lines = [];


### PR DESCRIPTION
Thanks for writing this tool. It is largely what we were looking to do ourselves for translations export/import. Although, when trying it for the first time on our project, I found that it was exiting silently when JSON.parse ran into an error.

It ended up being that we have comments and also some trailing commas in our `translations.json`. What we have in our .js file is indeed valid javascript, but not fully valid JSON.

Though it would be better to use a full JavaScript parser, having an error giving some indication of why the export bombed out would be very helpful.

Feel free to offer suggestions, if desired. Thanks!