### PR TITLE
Fixes #155 and documentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install -g ember-i18n-csv
 Export your ember-i18n localization files to a CSV file for translators:
 
 ```sh
-ember-i18n-csv to-csv --locales-path=path_to_locales_folder --csv-path=i18n.csv [--missing-only]
+ember-i18n-csv to-csv --locales-path=path_to_locales_folder --csv-path=i18n.csv [--only-missing]
 ```
 
 and import back in when you get them back:
@@ -32,7 +32,7 @@ and import back in when you get them back:
 ember-i18n-csv to-js --csv-path=i18n.csv --locales-path=path_to_locales_folder [--jshint-ignore] [--merge]
 ```
 
-`--missing-only` means the generated CSV will only contain keys where there is a missing translation in one of the locales
+`--only-missing` means the generated CSV will only contain keys where there is a missing translation in one of the locales
 
 `--jshint-ignore` will put ignore comments in your js files, useful if you lint for single quotes
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "babel lib -d dist",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "mocha --require babel-register test/**/*-test.js",
     "posttest": "npm run lint",
     "cover": "babel-node node_modules/isparta/bin/isparta cover --include-all-sources --report html --report lcov node_modules/mocha/bin/_mocha -- --require babel-register test/**/*-test.js",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "eol": "0.9.1",
     "lodash": "^4.0.0",
     "promise": "^8.0.0",
-    "yargs": "^11.0.0"
+    "yargs": "^11.0.0",
+    "fs-extra": "^6.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.0.0",
@@ -48,7 +49,6 @@
     "eslint-config-sane": "^0.6.0",
     "eslint-plugin-prefer-let": "^1.0.0",
     "fs-equal": "^1.0.0",
-    "fs-extra": "^5.0.0",
     "isparta": "^4.0.0",
     "mocha": "^5.0.0",
     "rimraf": "^2.0.0"


### PR DESCRIPTION
This fixes the following:

* #155
* Documentation error where it stated `--missing-only` but it was really `--only-missing`. 
* Issue where `prepublish` npm command is no longer running in latest NPM versions.  Replaced with `prepare`. This allows for installing via GIT and via NPM.